### PR TITLE
Update pytesseract_ocr.py

### DIFF
--- a/ocr_module/pytesseract/pytesseract_ocr.py
+++ b/ocr_module/pytesseract/pytesseract_ocr.py
@@ -1,4 +1,6 @@
 import base64
+import re
+
 from io import BytesIO
 
 from PIL import Image
@@ -13,4 +15,5 @@ def is_need_keys() -> bool:
 def get_result(img: bytes) -> str:
     img = base64.standard_b64decode(img)
     gray = Image.open(BytesIO(img)).resize((157,52))
-    return pytesseract.image_to_string(gray).strip()
+    text = pytesseract.image_to_string(gray).strip()
+    return ''.join(re.findall(r"-?[1-9]\d*", text))


### PR DESCRIPTION
## 修复了哪些Bug

pytesseract的检测结果经常带有符号，如：
```
1.234
3456$
87-90
```
然而验证码中不可能有符号，去掉符号的结果通常是正确的结果，因此我使用了正则表达式来去除符号。


## 增加了哪些功能

使用正则表达式对pytesseract的识别结果进行过滤，返回一个纯数字字符串，而不是夹杂了符号的字符串。

## 改动了哪些部分

ocr_module/pytesseract/pytesseract_ocr.py

具体看diff

## 关联的ISSUE

无

## 运行成功的日志

```text
[INFO]:你正在使用本地服务,请确保填写了配置文件
[INFO]:自动学习开始
[INFO]:set max retry 5
[INFO]:使用 OCR pytesseract
[INFO]:开始单人打卡
[INFO]:正在登录尾号0226
[INFO]:获取验证码成功: 28785
[ERROR]:尾号0226登录失败，原因：验证码错误！
[INFO]:尝试重新登录，重试次数0
[INFO]:获取验证码成功: 5585
[INFO]:0226 login 登录成功！
[INFO]:学习成功！
```

可以看到，还是有可能会有识别出超过4个字的情况，不过已经改善了很多:)