### PR TITLE
解决pytesseract中没有考虑到验证码包含0的情况

### DIFF
--- a/ocr_module/pytesseract/pytesseract_ocr.py
+++ b/ocr_module/pytesseract/pytesseract_ocr.py
@@ -16,4 +16,4 @@ def get_result(img: bytes) -> str:
     img = base64.standard_b64decode(img)
     gray = Image.open(BytesIO(img)).resize((157,52))
     text = pytesseract.image_to_string(gray).strip()
-    return ''.join(re.findall(r"-?[1-9]\d*", text))
+    return ''.join(re.findall(r"-?[0-9]\d*", text))


### PR DESCRIPTION
## 修复了哪些Bug

解决pytesseract中没有考虑到验证码包含0的情况。
非常抱歉！在上一个pr中没有认真验证，导致再次测试时发现这个问题。

## 改动了哪些部分

/ocr_module/pytesseract/pytesseract_ocr.py